### PR TITLE
Upgrade `puma` to v. 6 and fix `fixture_path` deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'sprockets-rails'
 gem 'sqlite3', '~> 1.4'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '~> 5.0'
+gem 'puma', '~> 6.0'
 
 # Use the grape framework do define our API
 gem 'grape'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       method_source (~> 1.0)
     psych (5.1.2)
       stringio
-    puma (5.6.8)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (3.0.9)
@@ -286,7 +286,7 @@ DEPENDENCIES
   grape
   grape-entity
   pry
-  puma (~> 5.0)
+  puma (~> 6.0)
   rack-test
   racksh
   rails (~> 7.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
This PR upgrades `puma` gem to v.6 as this was required to be able to run `specs`:

```
$ bundle exec rspec

An error occurred while loading ./spec/api/controllers/companies_controller_spec.rb.
Failure/Error: require_relative '../config/environment'

StandardError:
  Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher.
```

And also fixes a [deprecation warning from rails 7.1](https://rubyonrails.org/2023/3/18/this-week-in-rails-testfixtures-fixture_path-deprecation-findermethods-find-support-for-composite-primary-key-values-87e6e69a), when running the above `rspec` command:

```
Deprecation Warnings:

Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural:
```
